### PR TITLE
Implement a basic Game Boy memory

### DIFF
--- a/src/main/java/com/github/reisnera/gameboylfb/GameBoyAppLauncher.java
+++ b/src/main/java/com/github/reisnera/gameboylfb/GameBoyAppLauncher.java
@@ -18,6 +18,7 @@ public class GameBoyAppLauncher {
 	private static final Logger log = Logger.getLogger("Main Log");
 
 	static GameBoyRom rom = null;
+	static GameBoyMemory mem = null;
 
 	public static void main(String[] args) {
 		configureLogging();
@@ -32,8 +33,17 @@ public class GameBoyAppLauncher {
 
 		System.out.println(rom.hGameTitle);
 
-		GameBoyVideo video = new GameBoyVideo();
-		System.out.println("Goodbye!");
+		try {
+			mem = new GameBoyMemory(rom);
+		}
+		catch(Exception ex) {
+			log.log(Level.SEVERE, ex.toString(), ex);
+		}
+
+		// testing...
+		System.out.println(String.format("%x", mem.readByte((short)0)));
+		mem.disableDmgRom();
+		System.out.println(String.format("%x", mem.readByte((short)0)));
 	}
 
 	private static void configureLogging() {

--- a/src/main/java/com/github/reisnera/gameboylfb/GameBoyMemory.java
+++ b/src/main/java/com/github/reisnera/gameboylfb/GameBoyMemory.java
@@ -11,18 +11,49 @@ package com.github.reisnera.gameboylfb;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
+//import java.util.logging.Logger;
 
 public class GameBoyMemory {
-	private static final Logger log = Logger.getLogger("Main Log");
+	//private static final Logger log = Logger.getLogger("Main Log");
 
-	private final byte[] dmgRom;
+	private GameBoyRom rom;
+	private byte[] memory = new byte[65536];
 
 	public GameBoyMemory(GameBoyRom rom) throws IOException, MemoryBadDmgRomException {
-		dmgRom = Files.readAllBytes(Paths.get("../DMG_ROM.bin"));
+		this.rom = rom;
+
+		byte[] dmgRom = Files.readAllBytes(Paths.get("../DMG_ROM.bin"));
 		if(dmgRom.length != 256) {
 			throw new MemoryBadDmgRomException("Invalid DMG ROM length.");
 		}
+
+		// Copy 32kB cart ROM to beginning of memory (except first 256 bytes)
+		System.arraycopy(rom.romData, 256, memory, 256, 32512);
+		// Copy the DMG ROM to the first 256 bytes of memory
+		System.arraycopy(dmgRom, 0, memory, 0, 256);
 	}
 
+	public void disableDmgRom() {
+		// Overwrite the DMG ROM with the first 256 bytes of the cart ROM
+		System.arraycopy(rom.romData, 0, memory, 0, 256);
+	}
+
+	public byte readByte(short addr) {
+		// Take into account the mirrored RAM area
+		if(addr >= 0xE000 && addr < 0xFE00) {
+			addr -= 0x2000;
+		}
+		return memory[addr];
+	}
+
+	public void writeByte(byte data, short addr) throws MemoryRomWriteException {
+		if(addr < 0x8000) {
+			throw new MemoryRomWriteException(addr);
+		} else if(addr >= 0xE000 && addr < 0xFE00) {
+			// Take into account the mirrored RAM area
+			addr -= 0x2000;
+		}
+
+		memory[addr] = data;
+	}
 }

--- a/src/main/java/com/github/reisnera/gameboylfb/MemoryRomWriteException.java
+++ b/src/main/java/com/github/reisnera/gameboylfb/MemoryRomWriteException.java
@@ -1,0 +1,46 @@
+/* This file is part of the GameBoyLFB project.
+   GameBoyLFB - A Java Game Boy emulator.
+   Copyright (C) 2015 Alex Reisner <thearcher at gmail dot com>
+
+   This project is licensed under the GNU GPL v2 license and comes with
+   absolutely no warranty of any kind. The full license can be found at:
+   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt */
+
+package com.github.reisnera.gameboylfb;
+
+public class MemoryRomWriteException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	private final short romAddress;
+
+	public MemoryRomWriteException(short addr) {
+		super();
+		romAddress = addr;
+	}
+
+	public MemoryRomWriteException(String message, short addr) {
+		super(message);
+		romAddress = addr;
+	}
+
+	public MemoryRomWriteException(Throwable cause, short addr) {
+		super(cause);
+		romAddress = addr;
+	}
+
+	public MemoryRomWriteException(String message, Throwable cause, short addr) {
+		super(message, cause);
+		romAddress = addr;
+	}
+
+	public MemoryRomWriteException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace, short addr) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		romAddress = addr;
+	}
+
+	public short getRequestedRomAddress() {
+		return romAddress;
+	}
+}


### PR DESCRIPTION
Features include:
- read DMG ROM and place at beginning of memory before cart ROM
- disableDmgRom method copies first 256 bytes of cart ROM to memory
- read-only memory is read-only
- mirrored area of Game Boy RAM is indeed mirrored
- implement readByte and writeByte
